### PR TITLE
pages concurrency group を追加して、paged deploy が失敗しないように

### DIFF
--- a/.github/workflows/pull-request-vrt.yaml
+++ b/.github/workflows/pull-request-vrt.yaml
@@ -63,6 +63,9 @@ jobs:
     permissions:
       contents: write # for peaceiris/actions-gh-pages
       pull-requests: write # for yumemi-inc/comment-pull-request
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
       - uses: yumemi-inc/setup-java-gradle@v2


### PR DESCRIPTION
## issue 等（ない場合はなにを実装したかひとこと）

- issue: Close #

## 背景 なぜ実装したか

- `peaceiris/actions-gh-pages` は同時に複数走るとコンフリクトしてエラーになる

## 変更内容

-

## 動作確認手順

1.

## レビュー観点

-

## 備考
